### PR TITLE
Allow non-string rendered contents in v4

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -194,7 +194,6 @@ class DiffViewer extends React.Component<
       const content = renderer
         ? renderer(wordDiff.value as string)
         : wordDiff.value;
-      if (typeof content !== "string") return;
 
       return wordDiff.type === DiffType.ADDED ? (
         <ins


### PR DESCRIPTION
Closes #67.

I don’t fully understand the original purpose of the added line. But it was added in a seemingly unrelated commit: c0c99f5.