### PR TITLE
Fixup #68 for non-string wordDiff.value

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -193,7 +193,10 @@ class DiffViewer extends React.Component<
     return diffArray.map((wordDiff, i): JSX.Element => {
       const content = renderer
         ? renderer(wordDiff.value as string)
-        : wordDiff.value;
+        : (typeof wordDiff.value === 'string'
+          ? wordDiff.value
+          // If wordDiff.value is DiffInformation, we don't handle it, unclear why. See c0c99f5712.
+          : undefined);
 
       return wordDiff.type === DiffType.ADDED ? (
         <ins


### PR DESCRIPTION
In #68, we’ve added handling for renderer returning non-string values. But we also unintentionally changed the other conditional branch wordDiff.value, and that was not intended. Revert to the previous behavior for that branch.