### PR TITLE
Fix: Diff view renders "undefinedundefined..." suffix on lines with apostrophes

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -84,6 +84,7 @@ function applyDiffToHighlightedHtml(
       .replace(/&amp;/g, "&")
       .replace(/&quot;/g, '"')
       .replace(/&#39;/g, "'")
+      .replace(/&#x27;/g, "'")
       .replace(/&nbsp;/g, "\u00A0");
   }
 

--- a/test/react-diff-viewer.test.tsx
+++ b/test/react-diff-viewer.test.tsx
@@ -93,6 +93,62 @@ describe("Testing react diff viewer", (): void => {
     expect(duration).toBeLessThan(2000);
   });
 
+  it("Should not render 'undefined' when renderContent returns HTML with &#x27; entities", async (): Promise<void> => {
+    // Simulates highlight.js output which encodes apostrophes as &#x27;
+    // This was the root cause of the "undefinedundefined..." suffix bug
+    const oldValue = "const x = 'hello'";
+    const newValue = "const x = 'world'";
+
+    // Simulate a syntax highlighter (like highlight.js) that encodes
+    // apostrophes as &#x27; instead of &#39;
+    const renderContent = (str: string): React.ReactElement => {
+      const html = str.replace(/'/g, "&#x27;");
+      return <span dangerouslySetInnerHTML={{ __html: html }} />;
+    };
+
+    const node = render(
+      <DiffViewer
+        oldValue={oldValue}
+        newValue={newValue}
+        compareMethod={DiffMethod.WORDS_WITH_SPACE}
+        renderContent={renderContent}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(node.container.querySelector("table")).toBeTruthy();
+    });
+
+    const allContent = node.container.textContent || "";
+    expect(allContent).not.toContain("undefined");
+  });
+
+  it("Should not render 'undefined' with multiple apostrophes in renderContent HTML", async (): Promise<void> => {
+    const oldValue = "it's a 'test' isn't it";
+    const newValue = "it's a 'change' isn't it";
+
+    const renderContent = (str: string): React.ReactElement => {
+      const html = str.replace(/'/g, "&#x27;");
+      return <span dangerouslySetInnerHTML={{ __html: html }} />;
+    };
+
+    const node = render(
+      <DiffViewer
+        oldValue={oldValue}
+        newValue={newValue}
+        compareMethod={DiffMethod.WORDS_WITH_SPACE}
+        renderContent={renderContent}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(node.container.querySelector("table")).toBeTruthy();
+    });
+
+    const allContent = node.container.textContent || "";
+    expect(allContent).not.toContain("undefined");
+  });
+
   it("Should render JSON diff with keys preserved", async (): Promise<void> => {
     const oldObj = {
       data: {


### PR DESCRIPTION
## fix: Diff view renders "undefinedundefined…" suffix on lines with apostrophes

### Problem

When using `renderContent` with a syntax highlighter (e.g. highlight.js) and `DiffMethod.WORDS_WITH_SPACE`, any line containing apostrophes renders a spurious `undefinedundefinedundefined…` suffix. For a line with *N* apostrophes, exactly *8 × N* `"undefined"` strings are appended.

**Example:** a diff of `const x = 'hello'` → `const x = 'world'` renders as:

```
const x = 'world'undefinedundefinedundefinedundefinedundefinedundefinedundefinedundefined
```

### Root Cause

The full bug chain:

1. `WORDS_WITH_SPACE` triggers per-word diff rendering via `renderWordDiff`, which calls the user-supplied `renderContent` callback with the full reconstructed line.
2. `renderContent` typically calls `hljs.highlight()`, which internally encodes apostrophes using the **hex HTML entity** `&#x27;`:
   ```js
   // highlight.js escapeHTML
   .replace(/'/g, '&#x27;');
   ```
3. The returned highlighted HTML is passed to `applyDiffToHighlightedHtml`, which calls its `decodeEntities` helper to normalize entity lengths back to plain-text character counts:
   ```js
   // decodeEntities — BEFORE fix
   .replace(/&lt;/g, "<")
   .replace(/&gt;/g, ">")
   .replace(/&amp;/g, "&")
   .replace(/&quot;/g, '"')
   .replace(/&#39;/g, "'")    // ← handles decimal entity
   .replace(/&nbsp;/g, "\u00A0");
   // ❌ &#x27; (hex entity) is NOT handled
   ```
4. Because `&#x27;` (6 encoded chars) is **not** decoded to `'` (1 char), `decodedText.length` is **5 characters larger** than the actual plain-text length **per apostrophe**.
5. The word-diff character ranges are built from the plain-text `fullLine`, covering only `fullLine.length` characters. `applyDiffToHighlightedHtml` advances `textPos += decodedText.length` after each segment, causing `globalPos` to run **past the end** of all ranges while the outer loop still has remaining iterations.
6. In the `!range` fallback branch, the code reads:
   ```js
   const char = text[localEncodedPos];  // out-of-bounds → undefined
   result += char;                       // "undefined" string appended
   ```
7. For `'hello'` (2 apostrophes): `decodedText.length = 17`, `charsToTake = 9`, leaving `17 − 9 = 8` out-of-bounds iterations → exactly **8 × `"undefined"`**.

### Fix

**One-line change** in `src/index.tsx` — add `&#x27;` (hex entity) decoding to `decodeEntities` inside `applyDiffToHighlightedHtml`:

```diff
  .replace(/&quot;/g, '"')
  .replace(/&#39;/g, "'")
+ .replace(/&#x27;/g, "'")
  .replace(/&nbsp;/g, "\u00A0");
```

This ensures the hex-encoded apostrophe from highlight.js is decoded to the same single character that the plain-text diff ranges expect, keeping `decodedText.length` in sync with the actual character count.

### Tests Added

Two new integration tests in `test/react-diff-viewer.test.tsx`:

| Test | Description |
|------|-------------|
| `Should not render 'undefined' when renderContent returns HTML with &#x27; entities` | Single-quoted strings (`'hello'` → `'world'`) with `WORDS_WITH_SPACE` and a `renderContent` that encodes `'` as `&#x27;` — asserts no `"undefined"` in output |
| `Should not render 'undefined' with multiple apostrophes in renderContent HTML` | Multiple apostrophes (`it's a 'test' isn't it` → `it's a 'change' isn't it`) — asserts no `"undefined"` in output |

Both tests **fail without the fix** and **pass with it**.

### Verification

```
 ✓ test/react-diff-viewer.test.tsx (7 tests) 7 passed
```
